### PR TITLE
make client stop connecting to the server when auth:failure is followed by connection error

### DIFF
--- a/client/js/socket-events/auth.ts
+++ b/client/js/socket-events/auth.ts
@@ -20,7 +20,7 @@ socket.on("auth:success", function () {
 socket.on("auth:failed", async function () {
 	storage.remove("token");
 	store.commit("isAuthFailure", true);
-	
+
 	if (store.state.appLoaded) {
 		return reloadPage("Authentication failed, reloading…");
 	}

--- a/client/js/socket-events/auth.ts
+++ b/client/js/socket-events/auth.ts
@@ -12,13 +12,15 @@ declare global {
 }
 
 socket.on("auth:success", function () {
+	store.commit("isAuthFailure", false);
 	store.commit("currentUserVisibleError", "Loading messages…");
 	updateLoadingMessage();
 });
 
 socket.on("auth:failed", async function () {
 	storage.remove("token");
-
+	store.commit("isAuthFailure", true);
+	
 	if (store.state.appLoaded) {
 		return reloadPage("Authentication failed, reloading…");
 	}
@@ -27,6 +29,8 @@ socket.on("auth:failed", async function () {
 });
 
 socket.on("auth:start", async function (serverHash) {
+	store.commit("isAuthFailure", false);
+
 	// If we reconnected and serverHash differs, that means the server restarted
 	// And we will reload the page to grab the latest version
 	if (lastServerHash && serverHash !== lastServerHash) {

--- a/client/js/socket-events/connection.ts
+++ b/client/js/socket-events/connection.ts
@@ -76,7 +76,7 @@ function requestIdleCallback(callback, timeout) {
 		// until either the idle period ends or there are no more idle callbacks eligible to be run.
 		window.requestIdleCallback(callback, {timeout});
 	} else {
-	  	callback();
+		callback();
 	}
 }
 

--- a/client/js/socket-events/connection.ts
+++ b/client/js/socket-events/connection.ts
@@ -110,11 +110,12 @@ function updateErrorMessageAndExit(message: string) {
 	if ("serviceWorker" in navigator) {
 		navigator.serviceWorker.ready
 			.then((registration) => {
-			    registration.active?.postMessage({type: "shutdown"});
-                            registration.unregister().then((boolean) => {
-                                console.log("unreg worked");                        
-                                // if boolean == true unregister is succesful
-                            });                             
+				registration.active?.postMessage({type: "shutdown"});
+				registration
+					.unregister()
+					.catch((e) => {
+						// couldn't communicate with the service-worker
+					});
 			})
 			.catch((e) => {
 				// couldn't communicate with the service-worker

--- a/client/js/socket-events/connection.ts
+++ b/client/js/socket-events/connection.ts
@@ -111,11 +111,8 @@ function updateErrorMessageAndExit(message: string) {
 		navigator.serviceWorker.ready
 			.then((registration) => {
 				registration.active?.postMessage({type: "shutdown"});
-				registration
-					.unregister()
-					.catch((e) => {
-						// couldn't communicate with the service-worker
-					});
+				// unregister the worker to stop caching data
+				void registration.unregister();
 			})
 			.catch((e) => {
 				// couldn't communicate with the service-worker

--- a/client/js/socket-events/connection.ts
+++ b/client/js/socket-events/connection.ts
@@ -27,20 +27,21 @@ socket.on("connect", function () {
 
 function handleConnectError(data) {
 	const message = String(data.message || data);
-	
-        if (store.state.isAuthFailure) {
-             socket.disconnect();
-             return updateErrorMessage(`Disconnected from the server (${message}), Please close the tab and try again later.`);
-	 }
-	 
-	 return (handleDisconnect(data));
+
+	if (store.state.isAuthFailure) {
+		return updateErrorMessageAndExit(
+			`Disconnected from the server, Please close the tab and try again later.`
+		);
+	}
+
+	return handleDisconnect(data);
 }
 
 function handleDisconnect(data) {
 	const message = String(data.message || data);
 
 	store.commit("isConnected", false);
-	
+
 	if (!socket.io.reconnection()) {
 		store.commit(
 			"currentUserVisibleError",
@@ -80,11 +81,16 @@ function updateLoadingMessage() {
 	}
 }
 
-function updateErrorMessage(message: string) {
-        const parentDOM = document.getElementById("sign-in");
-        const error = parentDOM.getElementsByClassName("error")[0];
-    
-        if (error) {
-            error.textContent = message;
-        }
+function updateErrorMessageAndExit(message: string) {
+	socket.disconnect();
+
+	const parentDOM = document.getElementById("sign-in");
+
+	if (parentDOM) {
+		const error = parentDOM.getElementsByClassName("error")[0];
+
+		if (error) {
+			error.textContent = message;
+		}
+	}
 }

--- a/client/js/socket-events/connection.ts
+++ b/client/js/socket-events/connection.ts
@@ -28,16 +28,9 @@ socket.on("connect", function () {
 function handleConnectError(data) {
 	const message = String(data.message || data);
 	
-	console.error("connect-error");
-	console.error("isAuthFailure is ", store.state.isAuthFailure);
-
         if (store.state.isAuthFailure) {
-	    store.commit(	
-	            "currentUserVisibleError",
-		    `Disconnected from the server (${message}), Please close the tab and try again later.`
-	     );
-	     updateLoadingMessage();
-	     return;
+             socket.disconnect();
+             return updateErrorMessage(`Disconnected from the server (${message}), Please close the tab and try again later.`);
 	 }
 	 
 	 return (handleDisconnect(data));
@@ -47,7 +40,6 @@ function handleDisconnect(data) {
 	const message = String(data.message || data);
 
 	store.commit("isConnected", false);
-	console.error('isAuthfailure: ', store.state.isAuthFailure);
 	
 	if (!socket.io.reconnection()) {
 		store.commit(
@@ -86,4 +78,13 @@ function updateLoadingMessage() {
 	if (loading) {
 		loading.textContent = store.state.currentUserVisibleError;
 	}
+}
+
+function updateErrorMessage(message: string) {
+        const parentDOM = document.getElementById("sign-in");
+        const error = parentDOM.getElementsByClassName("error")[0];
+    
+        if (error) {
+            error.textContent = message;
+        }
 }

--- a/client/js/socket-events/connection.ts
+++ b/client/js/socket-events/connection.ts
@@ -30,7 +30,7 @@ function handleConnectError(data) {
 
 	if (store.state.isAuthFailure) {
 		return updateErrorMessageAndExit(
-			`Disconnected from the server, Please close the tab and try again later.`
+			`Disconnected from the server. Please close the tab and try again later.`
 		);
 	}
 
@@ -92,5 +92,15 @@ function updateErrorMessageAndExit(message: string) {
 		if (error) {
 			error.textContent = message;
 		}
+	}
+
+	if ("serviceWorker" in navigator) {
+		navigator.serviceWorker.ready
+			.then((registration) => {
+				registration.active?.postMessage({type: "shutdown"});
+			})
+			.catch((e) => {
+				// couldn't communicate with the service-worker
+			});
 	}
 }

--- a/client/js/store.ts
+++ b/client/js/store.ts
@@ -45,7 +45,7 @@ export type State = {
 	activeChannel?: NetChan;
 	currentUserVisibleError: string | null;
 	desktopNotificationState: DesktopNotificationState;
-	isAuthFailure : boolean;
+	isAuthFailure: boolean;
 	isAutoCompleting: boolean;
 	isConnected: boolean;
 	networks: ClientNetwork[];
@@ -89,7 +89,7 @@ const state = (): State => ({
 	activeChannel: undefined,
 	currentUserVisibleError: null,
 	desktopNotificationState: detectDesktopNotificationState(),
-	isAuthFailure : false,
+	isAuthFailure: false,
 	isAutoCompleting: false,
 	isConnected: false,
 	networks: [],

--- a/client/js/store.ts
+++ b/client/js/store.ts
@@ -45,6 +45,7 @@ export type State = {
 	activeChannel?: NetChan;
 	currentUserVisibleError: string | null;
 	desktopNotificationState: DesktopNotificationState;
+	disableReconnection: boolean;
 	isAuthFailure: boolean;
 	isAutoCompleting: boolean;
 	isConnected: boolean;
@@ -89,6 +90,7 @@ const state = (): State => ({
 	activeChannel: undefined,
 	currentUserVisibleError: null,
 	desktopNotificationState: detectDesktopNotificationState(),
+	disableReconnection: false,
 	isAuthFailure: false,
 	isAutoCompleting: false,
 	isConnected: false,
@@ -203,6 +205,7 @@ type Mutations = {
 	activeChannel(state: State, netChan: State["activeChannel"]): void;
 	currentUserVisibleError(state: State, error: State["currentUserVisibleError"]): void;
 	refreshDesktopNotificationState(state: State): void;
+	disableReconnection(state: State, payload: State["disableReconnection"]): void;
 	isAuthFailure(state: State, payload: State["isAuthFailure"]): void;
 	isAutoCompleting(state: State, isAutoCompleting: State["isAutoCompleting"]): void;
 	isConnected(state: State, payload: State["isConnected"]): void;
@@ -247,6 +250,9 @@ const mutations: Mutations = {
 	},
 	refreshDesktopNotificationState(state) {
 		state.desktopNotificationState = detectDesktopNotificationState();
+	},
+	disableReconnection(state, payload) {
+		state.disableReconnection = payload;
 	},
 	isAuthFailure(state, payload) {
 		state.isAuthFailure = payload;

--- a/client/js/store.ts
+++ b/client/js/store.ts
@@ -48,7 +48,6 @@ export type State = {
 	isAuthFailure : boolean;
 	isAutoCompleting: boolean;
 	isConnected: boolean;
-	reconnectionPause: boolean;
 	networks: ClientNetwork[];
 	// TODO: type
 	mentions: ClientMention[];
@@ -93,7 +92,6 @@ const state = (): State => ({
 	isAuthFailure : false,
 	isAutoCompleting: false,
 	isConnected: false,
-	reconnectionPause: false,
 	networks: [],
 	mentions: [],
 	hasServiceWorker: false,
@@ -208,7 +206,6 @@ type Mutations = {
 	isAuthFailure(state: State, payload: State["isAuthFailure"]): void;
 	isAutoCompleting(state: State, isAutoCompleting: State["isAutoCompleting"]): void;
 	isConnected(state: State, payload: State["isConnected"]): void;
-	reconnectionPause(state: State, payload: State["reconnectionPause"]): void;		
 	networks(state: State, networks: State["networks"]): void;
 	mentions(state: State, mentions: State["mentions"]): void;
 
@@ -260,9 +257,6 @@ const mutations: Mutations = {
 	isConnected(state, payload) {
 		state.isConnected = payload;
 	},
-	reconnectionPause(state, payload) {
-		state.reconnectionPause = payload;
-	},		
 	networks(state, networks) {
 		state.networks = networks;
 	},

--- a/client/js/store.ts
+++ b/client/js/store.ts
@@ -45,8 +45,10 @@ export type State = {
 	activeChannel?: NetChan;
 	currentUserVisibleError: string | null;
 	desktopNotificationState: DesktopNotificationState;
+	isAuthFailure : boolean;
 	isAutoCompleting: boolean;
 	isConnected: boolean;
+	reconnectionPause: boolean;
 	networks: ClientNetwork[];
 	// TODO: type
 	mentions: ClientMention[];
@@ -88,8 +90,10 @@ const state = (): State => ({
 	activeChannel: undefined,
 	currentUserVisibleError: null,
 	desktopNotificationState: detectDesktopNotificationState(),
+	isAuthFailure : false,
 	isAutoCompleting: false,
 	isConnected: false,
+	reconnectionPause: false,
 	networks: [],
 	mentions: [],
 	hasServiceWorker: false,
@@ -201,8 +205,10 @@ type Mutations = {
 	activeChannel(state: State, netChan: State["activeChannel"]): void;
 	currentUserVisibleError(state: State, error: State["currentUserVisibleError"]): void;
 	refreshDesktopNotificationState(state: State): void;
+	isAuthFailure(state: State, payload: State["isAuthFailure"]): void;
 	isAutoCompleting(state: State, isAutoCompleting: State["isAutoCompleting"]): void;
 	isConnected(state: State, payload: State["isConnected"]): void;
+	reconnectionPause(state: State, payload: State["reconnectionPause"]): void;		
 	networks(state: State, networks: State["networks"]): void;
 	mentions(state: State, mentions: State["mentions"]): void;
 
@@ -245,12 +251,18 @@ const mutations: Mutations = {
 	refreshDesktopNotificationState(state) {
 		state.desktopNotificationState = detectDesktopNotificationState();
 	},
+	isAuthFailure(state, payload) {
+		state.isAuthFailure = payload;
+	},
 	isAutoCompleting(state, isAutoCompleting) {
 		state.isAutoCompleting = isAutoCompleting;
 	},
 	isConnected(state, payload) {
 		state.isConnected = payload;
 	},
+	reconnectionPause(state, payload) {
+		state.reconnectionPause = payload;
+	},		
 	networks(state, networks) {
 		state.networks = networks;
 	},

--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -7,6 +7,7 @@ const cacheName = "__HASH__";
 const excludedPathsFromCache = /^(?:socket\.io|storage|uploads|cdn-cgi)\//;
 
 self.addEventListener("install", function () {
+	self.shutdown = false;
 	self.skipWaiting();
 });
 
@@ -25,6 +26,10 @@ self.addEventListener("activate", function (event) {
 });
 
 self.addEventListener("fetch", function (event) {
+	if (self.shutdown) {
+		return;
+	}
+
 	if (event.request.method !== "GET") {
 		return;
 	}
@@ -110,6 +115,10 @@ async function networkOrCache(event) {
 }
 
 self.addEventListener("message", function (event) {
+	if (event.data.type === "shutdown") {
+		self.shutdown = true;
+	}
+
 	showNotification(event, event.data);
 });
 


### PR DESCRIPTION
When the server returns a 403 and closes the connections, if the client was still in the authentication phase, assume the server has blocked access during a while. We then have the client inform the user to close the tab and try again later and unenregister the service-worker.

All of this to avoid having the client continue to flood the server with connection attempts, which would only increase the connection ban by the server.